### PR TITLE
wip: invoivces enable paginated response

### DIFF
--- a/controllers/invoicestream.ctrl.go
+++ b/controllers/invoicestream.ctrl.go
@@ -119,7 +119,7 @@ func createWebsocketUpgrader(c echo.Context) (conn *websocket.Conn, done chan st
 }
 
 func (controller *InvoiceStreamController) writeMissingInvoices(c echo.Context, userId int64, ws *websocket.Conn, hash string) error {
-	invoices, err := controller.svc.InvoicesFor(c.Request().Context(), userId, common.InvoiceTypeIncoming)
+	invoices, _, err := controller.svc.InvoicesFor(c.Request().Context(), userId, common.InvoiceTypeIncoming)
 	if err != nil {
 		return err
 	}

--- a/controllers_v2/invoice.ctrl.go
+++ b/controllers_v2/invoice.ctrl.go
@@ -53,7 +53,7 @@ type Invoice struct {
 func (controller *InvoiceController) GetOutgoingInvoices(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
 
-	invoices, err := controller.svc.InvoicesFor(c.Request().Context(), userId, common.InvoiceTypeOutgoing)
+	invoices, _, err := controller.svc.InvoicesFor(c.Request().Context(), userId, common.InvoiceTypeOutgoing)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (controller *InvoiceController) GetOutgoingInvoices(c echo.Context) error {
 func (controller *InvoiceController) GetIncomingInvoices(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
 
-	invoices, err := controller.svc.InvoicesFor(c.Request().Context(), userId, common.InvoiceTypeIncoming)
+	invoices, _, err := controller.svc.InvoicesFor(c.Request().Context(), userId, common.InvoiceTypeIncoming)
 	if err != nil {
 		return err
 	}

--- a/integration_tests/hodl_invoice_test.go
+++ b/integration_tests/hodl_invoice_test.go
@@ -144,7 +144,7 @@ func (suite *HodlInvoiceSuite) TestHodlInvoice() {
 	}
 	assert.Equal(suite.T(), int64(userFundingSats), userBalance)
 
-	invoices, err := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
+	invoices, _, err := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
 	if err != nil {
 		fmt.Printf("Error when getting invoices %v\n", err.Error())
 	}

--- a/integration_tests/internal_payment_test.go
+++ b/integration_tests/internal_payment_test.go
@@ -232,7 +232,7 @@ func (suite *PaymentTestSuite) TestInternalPaymentFail() {
 	_ = suite.createPayInvoiceReqError(bobInvoice.PayReq, suite.aliceToken)
 
 	userId := getUserIdFromToken(suite.aliceToken)
-	invoices, err := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
+	invoices, _, err := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
 	if err != nil {
 		fmt.Printf("Error when getting invoices %v\n", err.Error())
 	}
@@ -301,7 +301,7 @@ func (suite *PaymentTestSuite) TestInternalPaymentKeysend() {
 	bobBalance, _ := suite.service.CurrentUserBalance(context.Background(), bobId)
 	assert.Equal(suite.T(), int64(bobAmt)+previousBobBalance, bobBalance)
 	//check bob's invoices for whatsat message
-	invoicesBob, _ := suite.service.InvoicesFor(context.Background(), bobId, common.InvoiceTypeIncoming)
+	invoicesBob, _, _ := suite.service.InvoicesFor(context.Background(), bobId, common.InvoiceTypeIncoming)
 	foundKeySend := false
 	for _, invoice := range invoicesBob {
 		if invoice.Keysend {

--- a/integration_tests/invoice_test.go
+++ b/integration_tests/invoice_test.go
@@ -73,13 +73,13 @@ func (suite *InvoiceTestSuite) TestZeroAmtTestSuite() {
 
 func (suite *InvoiceTestSuite) TestAddInvoiceWithoutToken() {
 	user, _ := suite.service.FindUserByLogin(context.Background(), suite.aliceLogin.Login)
-	invoicesBefore, _ := suite.service.InvoicesFor(context.Background(), user.ID, common.InvoiceTypeIncoming)
+	invoicesBefore, _, _ := suite.service.InvoicesFor(context.Background(), user.ID, common.InvoiceTypeIncoming)
 	assert.Equal(suite.T(), 0, len(invoicesBefore))
 
 	suite.createInvoiceReq(10, "test invoice without token", suite.aliceLogin.Login)
 
 	// check if invoice is added
-	invoicesAfter, _ := suite.service.InvoicesFor(context.Background(), user.ID, common.InvoiceTypeIncoming)
+	invoicesAfter, _, _ := suite.service.InvoicesFor(context.Background(), user.ID, common.InvoiceTypeIncoming)
 	assert.Equal(suite.T(), 1, len(invoicesAfter))
 }
 

--- a/integration_tests/outgoing_payment_test.go
+++ b/integration_tests/outgoing_payment_test.go
@@ -58,8 +58,8 @@ func (suite *PaymentTestSuite) TestOutGoingPayment() {
 	outgoingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeOutgoing, userId)
 	currentAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeCurrent, userId)
 
-	outgoingInvoices, _ := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
-	incomingInvoices, _ := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeIncoming)
+	outgoingInvoices, _, _ := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
+	incomingInvoices, _, _ := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeIncoming)
 	assert.Equal(suite.T(), 1, len(outgoingInvoices))
 	assert.Equal(suite.T(), 1, len(incomingInvoices))
 
@@ -144,8 +144,8 @@ func (suite *PaymentTestSuite) TestOutGoingPaymentWithNegativeBalance() {
 	outgoingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeOutgoing, userId)
 	currentAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeCurrent, userId)
 
-	outgoingInvoices, _ := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
-	incomingInvoices, _ := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeIncoming)
+	outgoingInvoices, _, _ := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
+	incomingInvoices, _, _ := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeIncoming)
 	assert.Equal(suite.T(), 1, len(outgoingInvoices))
 	assert.Equal(suite.T(), 1, len(incomingInvoices))
 

--- a/integration_tests/payment_failure_async_test.go
+++ b/integration_tests/payment_failure_async_test.go
@@ -118,7 +118,7 @@ func (suite *PaymentTestAsyncErrorsSuite) TestExternalAsyncFailingInvoice() {
 	}
 	assert.Equal(suite.T(), int64(userFundingSats), userBalance)
 
-	invoices, err := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
+	invoices, _, err := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
 	if err != nil {
 		fmt.Printf("Error when getting invoices %v\n", err.Error())
 	}

--- a/integration_tests/payment_failure_test.go
+++ b/integration_tests/payment_failure_test.go
@@ -90,8 +90,8 @@ func (suite *PaymentTestErrorsSuite) TestExternalFailingInvoice() {
 
 	//test an expired invoice
 	externalInvoice := lnrpc.Invoice{
-		Memo:  "integration tests: external pay from alice",
-		Value: int64(externalSatRequested),
+		Memo:   "integration tests: external pay from alice",
+		Value:  int64(externalSatRequested),
 		Expiry: 1,
 	}
 	invoice, err := suite.externalLND.AddInvoice(context.Background(), &externalInvoice)
@@ -130,7 +130,7 @@ func (suite *PaymentTestErrorsSuite) TestExternalFailingInvoice() {
 
 	userId := getUserIdFromToken(suite.userToken)
 
-	invoices, err := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
+	invoices, _, err := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
 	if err != nil {
 		fmt.Printf("Error when getting invoices %v\n", err.Error())
 	}


### PR DESCRIPTION
This is an early version draft about implementing pagination for the list invoices request. This feature might be useful in the near future if the Alby lightning-browser-extension wants to implement pagination for transactions pages. As I was debugging the codebase recently, I just got curious how this could be implemented.

One of the things to be discussed is the`InvoicesResponseBody` interface. A better idea might be to have two properties 
```
{
    data: [
        ...
    ],
    meta: {
        current_page: 1,
        page_size: 100,
        total_entries: 123,
        total_pages: 2,
    }
}
```

I guess this is pretty opinionated and you might have better ideas.

For now this targets the legacy endpoints, but I would add it to v2 endpoints as well.